### PR TITLE
[TEST] Add test simulator app workflow

### DIFF
--- a/.github/workflows/test-simulator-app-workflow.yml
+++ b/.github/workflows/test-simulator-app-workflow.yml
@@ -12,14 +12,5 @@ jobs:
                 device: ['iPhone 12']
 
         steps:
-            - name: Switch Xcode version to ${{ matrix.xcode }}
-              run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app
-
-            - name: Print simulators list
-              run: xcrun simctl list --json
-
-            - name: Force booting Simulator app
-              run: xcrun simctl boot "${{ matrix.device }}"
-
             - name: Bring Simulator to the foreground
               run: open -Fn /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer/Applications/Simulator.app

--- a/.github/workflows/test-simulator-app-workflow.yml
+++ b/.github/workflows/test-simulator-app-workflow.yml
@@ -1,0 +1,24 @@
+name: Test Simulator app
+
+on:
+    pull_request:
+
+jobs:
+    test:
+        runs-on: macos-11
+        strategy:
+            matrix:
+                xcode: [12.5.1]
+
+        steps:
+            - name: Switch Xcode version to ${{ matrix.xcode }}
+              run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app
+
+            - name: Print simulators list
+              run: xcrun simctl list --json
+
+            - name: Force booting Simulator app
+              run: xcrun simctl boot "${{ matrix.device }}"
+
+            - name: Bring Simulator to the foreground
+              run: open -Fn /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer/Applications/Simulator.app

--- a/.github/workflows/test-simulator-app-workflow.yml
+++ b/.github/workflows/test-simulator-app-workflow.yml
@@ -8,7 +8,8 @@ jobs:
         runs-on: macos-11
         strategy:
             matrix:
-                xcode: [12.5.1]
+                xcode: ['13.0']
+                device: ['iPhone 12']
 
         steps:
             - name: Switch Xcode version to ${{ matrix.xcode }}

--- a/.github/workflows/test-simulator-app-workflow.yml
+++ b/.github/workflows/test-simulator-app-workflow.yml
@@ -9,8 +9,7 @@ jobs:
         strategy:
             matrix:
                 xcode: ['13.0']
-                device: ['iPhone 12']
 
         steps:
-            - name: Bring Simulator to the foreground
+            - name: Open Simulator app
               run: open -Fn /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer/Applications/Simulator.app


### PR DESCRIPTION
This PR adds a basic GitHub actions workflow that only runs the following command with the purpose of reproducing the `executable is missing` failure when trying to open the Simulator app:
```
open -Fn /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer/Applications/Simulator.app
```